### PR TITLE
Make footsteps produce sounds in their respective sound category

### DIFF
--- a/src/main/java/eu/ha3/presencefootsteps/sound/player/ImmediateSoundPlayer.java
+++ b/src/main/java/eu/ha3/presencefootsteps/sound/player/ImmediateSoundPlayer.java
@@ -82,7 +82,7 @@ public class ImmediateSoundPlayer implements SoundPlayer, StepSoundPlayer {
 
     private PositionedSoundInstance createSound(Identifier id, float volume, float pitch, Entity entity) {
         return new PositionedSoundInstance(id,
-                SoundCategory.MASTER,
+                entity.getSoundCategory(),
                 volume, pitch, false, 0,
                 SoundInstance.AttenuationType.LINEAR,
                 (float) entity.getX(),


### PR DESCRIPTION
It isn't a huge deal, but I noticed that all footstep sounds are played in the master category. This means the volume of footsteps won't change if I turn down the volume of players/friendly creatures/hostile creatures individually. This isn't consistent with the behavior of vanilla Minecraft, in which footstep sounds are played in the entity's sound category. 

This change should make the footsteps play sounds in the right category.