### PR TITLE
Remove a print line causing spam for wing flaps

### DIFF
--- a/src/main/java/eu/ha3/presencefootsteps/sound/generator/WingedStepSoundGenerator.java
+++ b/src/main/java/eu/ha3/presencefootsteps/sound/generator/WingedStepSoundGenerator.java
@@ -127,7 +127,6 @@ class WingedStepSoundGenerator extends TerrestrialStepSoundGenerator {
                         variator.WING_IMMOBILE_FADE_START,
                         variator.WING_IMMOBILE_FADE_START + variator.WING_IMMOBILE_FADE_DURATION);
             }
-            System.out.println("DFinal: " + volume + " === " + Options.singular("gliding_volume", volume).get("gliding_volume"));
 
             acoustics.playAcoustic(ply, "_WING", State.WALK, Options.singular("gliding_volume", volume));
         }


### PR DESCRIPTION
Whenever the wing flap sound plays as a stance with wings, the minecraft log would display `[STDOUT]: DFinal: <volume> === <volume>`. This could easily spam the log, especially when flying around in creative. This removes that unnecessary (presumably used as debug but accidentally left in) print line.