### PR TITLE
Fixed incorrect translation key for settings menu keybind

### DIFF
--- a/src/main/java/eu/ha3/presencefootsteps/PresenceFootsteps.java
+++ b/src/main/java/eu/ha3/presencefootsteps/PresenceFootsteps.java
@@ -76,7 +76,7 @@ public class PresenceFootsteps implements ClientModInitializer {
         config = new PFConfig(pfFolder.resolve("userconfig.json"), this);
         config.load();
 
-        keyBinding = new KeyBinding("presencefootsteps.settings.key", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_F10, "key.categories.misc");
+        keyBinding = new KeyBinding("key.presencefootsteps.settings", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_F10, "key.categories.misc");
 
         KeyBindingHelper.registerKeyBinding(keyBinding);
 


### PR DESCRIPTION
"presencefootsteps.settings.key" was being set instead of "key.presencefootsteps.settings" as translation key for settings menu keybinding