### PR TITLE
Fix multiplayer local player footstep cadence

### DIFF
--- a/src/main/java/eu/ha3/presencefootsteps/sound/generator/MotionTracker.java
+++ b/src/main/java/eu/ha3/presencefootsteps/sound/generator/MotionTracker.java
@@ -3,6 +3,7 @@ package eu.ha3.presencefootsteps.sound.generator;
 import eu.ha3.presencefootsteps.config.Variator;
 import eu.ha3.presencefootsteps.sound.State;
 import eu.ha3.presencefootsteps.util.PlayerUtil;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.OtherClientPlayerEntity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -63,8 +64,16 @@ public class MotionTracker {
             motionX = ply.getVelocity().x;
             motionY = ply.getVelocity().y;
             motionZ = ply.getVelocity().z;
-            distanceTraveled = ply.distanceTraveled;
-            fallDistance = ply.fallDistance;
+
+            if (MinecraftClient.getInstance().isInSingleplayer()) {
+                distanceTraveled = ply.distanceTraveled;
+                fallDistance = ply.fallDistance;
+            } else {
+                // On dedicated servers, the local player's distance counter does not
+                // advance like it does in singleplayer. Use the same motion-based
+                // accumulation model we already use for remote players.
+                accumulateSimulatedDistance(ply, false);
+            }
         } else {
             // Other players don't send their motion data so we have to make our own
             // approximations.
@@ -83,20 +92,7 @@ public class MotionTracker {
         }
 
         if (ply instanceof OtherClientPlayerEntity other) {
-            if (ply.getEntityWorld().getTime() % 1 == 0) {
-
-                if (motionX != 0 || motionZ != 0) {
-                    distanceTraveled += Math.sqrt(Math.pow(motionX, 2) + Math.pow(motionY, 2) + Math.pow(motionZ, 2)) * 0.8;
-                } else {
-                    distanceTraveled += Math.sqrt(Math.pow(motionX, 2) + Math.pow(motionZ, 2)) * 0.8;
-                }
-
-                if (ply.isOnGround() || ply.hasVehicle() || other.getAbilities().flying || motionY > 0) {
-                    fallDistance = 0;
-                } else if (motionY < 0) {
-                    fallDistance -= motionY;
-                }
-            }
+            accumulateSimulatedDistance(ply, other.getAbilities().flying);
         }
 
         if (!(ply instanceof PlayerEntity)) {
@@ -124,5 +120,23 @@ public class MotionTracker {
         double relativeSpeed = getHorizontalSpeed() + (getMotionY() * getMotionY()) - variator.RUNNING_RAMPUP_BEGIN;
         double maxSpeed = variator.RUNNING_RAMPUP_END - variator.RUNNING_RAMPUP_BEGIN;
         return (float)MathHelper.clamp(relativeSpeed / maxSpeed, 0, 1);
+    }
+
+    private void accumulateSimulatedDistance(LivingEntity ply, boolean flying) {
+        if (ply.getEntityWorld().getTime() % 1 != 0) {
+            return;
+        }
+
+        if (motionX != 0 || motionZ != 0) {
+            distanceTraveled += Math.sqrt(Math.pow(motionX, 2) + Math.pow(motionY, 2) + Math.pow(motionZ, 2)) * 0.8;
+        } else {
+            distanceTraveled += Math.sqrt(Math.pow(motionX, 2) + Math.pow(motionZ, 2)) * 0.8;
+        }
+
+        if (ply.isOnGround() || ply.hasVehicle() || flying || motionY > 0) {
+            fallDistance = 0;
+        } else if (motionY < 0) {
+            fallDistance -= motionY;
+        }
     }
 }


### PR DESCRIPTION
Fixes an issue where the local player on dedicated multiplayer servers produces footsteps at a significantly slower cadence than in singleplayer.

## Problem

For the local player, the client normally uses the built-in distance-traveled counter to pace footstep events. On dedicated servers the same signal does not advance consistently enough, which makes footsteps sound noticeably slower, and trigger less walk events.

## Fix

Keep the existing singleplayer behavior, but for the local player on dedicated servers switch to the same motion-based distance accumulation model already used for remote players.

This keeps singleplayer unchanged while restoring multiplayer cadence for the local player.

## Considerations

`0.8` is reused from "remote player" logic. In practice, it feels a hair slower when compared to SP, but it's probably fine. I would look into tweaking both together before touching that further.

There are other stale issues in regard to some sounds being irreproducibly slower on MP vs SP. I think those might be related to this quirk, as some materials' wander sounds are a lot quieter, and of course network conditions vary.

For my case, I was trying to walk on copper grates, and this would almost exclusively play the wander sound. If I overwrote the wander sound with the walk sound, footsteps were 3x slower, which tipped me off to this.