### PR TITLE
Fix delayed sounds never playing

### DIFF
--- a/src/main/java/eu/ha3/presencefootsteps/sound/player/DelayedSoundPlayer.java
+++ b/src/main/java/eu/ha3/presencefootsteps/sound/player/DelayedSoundPlayer.java
@@ -74,10 +74,11 @@ public class DelayedSoundPlayer implements SoundPlayer {
             this.pitch = pitch;
             this.options = options;
             maximum = options.containsKey("skippable") ? -1L : (long)options.get("delay_max");
-            timeToPlay = System.currentTimeMillis() + Math.max(MathUtil.randAB(getRNG(),
+            timeToPlay = System.currentTimeMillis() + MathUtil.randAB(getRNG(),
                     (long)options.get("delay_min"),
                     (long)options.get("delay_max")
-            ), nextPlayTime);
+            );
+            nextPlayTime = Math.min(nextPlayTime, timeToPlay);
         }
 
         public boolean tick() {


### PR DESCRIPTION
Appears this got jumbled a bit during a past refactor (a26983720).

Afaict `timeToPlay` should simply be the time (in millis since unix epoch) at which this particular delayed sound should play. So `now + random delay`.
`nextPlayTime` is the time (in millis since unix epoch) at which the earliest of the delayed sounds wants to be played (can become `Long.MAX_VALUE` when there aren't any pending sounds). Adding `nextPlayTime` to `System.currentTimeMillis` doesn't make much sense since both are millis since the unix epoch, and their combination will just be a timestamp around the year 2083.

What I believe was supposed to happen here instead, was to set the `nextPlayTime` to the minimum of its current value and `timeToPlay`, so we wake up sooner if the new sound wants to play before what was the earliest sound before it.

This fixes the delayed sound player effectively becoming "stuck" (waiting for 2083 or worse), which breaks delayed sounds, and (which is how I noticed this) indirectly keeps all worlds in which such sounds were supposed to be played from being garbage collected.