### PR TITLE
Fix delayed sounds playing multiple times

### DIFF
--- a/src/main/java/eu/ha3/presencefootsteps/sound/player/DelayedSoundPlayer.java
+++ b/src/main/java/eu/ha3/presencefootsteps/sound/player/DelayedSoundPlayer.java
@@ -84,7 +84,7 @@ public class DelayedSoundPlayer implements SoundPlayer {
             switch (nextState(currentTime)) {
                 case PLAYING:
                     immediate.playSound(location, soundName, volume, pitch, options);
-                    return false;
+                    return true;
                 case SKIPPING:
                     return true;
                 default:


### PR DESCRIPTION
After the sound has been played, it should be removed. Otherwise it may be played again if `tick` is called again (e.g. because another delayed sound is due for playback) before its max delay has passed (after which point it would be go down the `SKIPPING` case and properly remove the sound).

This is also how it used to behave prior to a26983720 (note how the `iter.remove` call is outside the skip-vs-play `if` in `AcousticsManager.think`).

I have **not** tried to re-produce this issue, nor validated the fix. I just noticed that the code seems wrong while trying to understand how the class works for https://github.com/Sollace/Presence-Footsteps/pull/416.