### PR TITLE
Fix player making double landing sound after jumping and landing

### DIFF
--- a/src/main/java/eu/ha3/presencefootsteps/sound/generator/TerrestrialStepSoundGenerator.java
+++ b/src/main/java/eu/ha3/presencefootsteps/sound/generator/TerrestrialStepSoundGenerator.java
@@ -23,6 +23,7 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.animal.equine.AbstractHorse;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.equipment.Equippable;
 
 class TerrestrialStepSoundGenerator implements StepSoundGenerator {
@@ -308,7 +309,11 @@ class TerrestrialStepSoundGenerator implements StepSoundGenerator {
 
         if (lastFallDistance > 0) {
             if (lastFallDistance > variator.LAND_HARD_DISTANCE_MIN) {
-                playMultifoot(getOffsetMinus(), State.LAND);
+                if (entity instanceof Player) {
+                    playSinglefoot(getOffsetMinus(), motionTracker.pickState(entity, State.CLIMB, State.CLIMB_RUN), isRightFoot);
+                } else {
+                    playMultifoot(getOffsetMinus(), State.LAND);
+                }
                 // Always assume the player lands on their two feet
                 // Do not toggle foot:
                 // After landing sounds, the first foot will be same as the one used to jump.


### PR DESCRIPTION
This PR adresses an issue with 1.13.3+26.2 where players, after jumping will make a double landing sound.