### PR TITLE
Remove pending sound that are not in the current world

### DIFF
--- a/src/main/java/eu/ha3/presencefootsteps/sound/player/DelayedSoundPlayer.java
+++ b/src/main/java/eu/ha3/presencefootsteps/sound/player/DelayedSoundPlayer.java
@@ -7,7 +7,9 @@ import eu.ha3.presencefootsteps.PresenceFootsteps;
 import eu.ha3.presencefootsteps.sound.Options;
 import eu.ha3.presencefootsteps.util.MathUtil;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.world.World;
 
 public class DelayedSoundPlayer implements SoundPlayer {
     private static final boolean USING_LATENESS = true;
@@ -51,7 +53,8 @@ public class DelayedSoundPlayer implements SoundPlayer {
 
         nextPlayTime = Long.MAX_VALUE;
 
-        pending.removeIf(PendingSound::tick);
+        World currentWorld = MinecraftClient.getInstance().world;
+        pending.removeIf(s -> s.tick() || s.location.getWorld() != currentWorld);
     }
 
     private class PendingSound {

--- a/src/main/java/eu/ha3/presencefootsteps/sound/player/DelayedSoundPlayer.java
+++ b/src/main/java/eu/ha3/presencefootsteps/sound/player/DelayedSoundPlayer.java
@@ -9,7 +9,6 @@ import eu.ha3.presencefootsteps.util.MathUtil;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.world.World;
 
 public class DelayedSoundPlayer implements SoundPlayer {
     private static final boolean USING_LATENESS = true;
@@ -53,8 +52,7 @@ public class DelayedSoundPlayer implements SoundPlayer {
 
         nextPlayTime = Long.MAX_VALUE;
 
-        World currentWorld = MinecraftClient.getInstance().world;
-        pending.removeIf(s -> s.tick() || s.location.getWorld() != currentWorld);
+        pending.removeIf(PendingSound::tick);
     }
 
     private class PendingSound {
@@ -83,6 +81,10 @@ public class DelayedSoundPlayer implements SoundPlayer {
         }
 
         public boolean tick() {
+            if (location.getWorld() != MinecraftClient.getInstance().world) {
+                return true;
+            }
+
             switch (nextState(currentTime)) {
                 case PLAYING:
                     immediate.playSound(location, soundName, volume, pitch, options);


### PR DESCRIPTION
I'm not sure what causes it. According to heap dump, there can be pending sounds staying in the queue, leaking tens of world in memory.

Also, I feel like the return value of the PLAYING case in `DelayedSoundPlayer$PendingSound:tick` should be true, but not entirely sure.